### PR TITLE
feat: .NET 8 WPF/MVVM skeleton + Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore src/AutoRace.sln
+
+      - name: Build
+        run: dotnet build src/AutoRace.sln -c Release --no-restore

--- a/src/AutoRace.App/App.xaml
+++ b/src/AutoRace.App/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="AutoRace.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AutoRace.App"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/src/AutoRace.App/App.xaml.cs
+++ b/src/AutoRace.App/App.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace AutoRace.App;
+
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
+{
+}
+

--- a/src/AutoRace.App/AssemblyInfo.cs
+++ b/src/AutoRace.App/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/src/AutoRace.App/AutoRace.App.csproj
+++ b/src/AutoRace.App/AutoRace.App.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoRace.Core\AutoRace.Core.csproj" />
+    <ProjectReference Include="..\AutoRace.Infrastructure\AutoRace.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+</Project>

--- a/src/AutoRace.App/MainWindow.xaml
+++ b/src/AutoRace.App/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="AutoRace.App.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AutoRace.App"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+
+    </Grid>
+</Window>

--- a/src/AutoRace.App/MainWindow.xaml.cs
+++ b/src/AutoRace.App/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AutoRace.App;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/AutoRace.Core/AutoRace.Core.csproj
+++ b/src/AutoRace.Core/AutoRace.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/AutoRace.Core/Class1.cs
+++ b/src/AutoRace.Core/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace AutoRace.Core;
+
+public class Class1
+{
+
+}

--- a/src/AutoRace.Infrastructure/AutoRace.Infrastructure.csproj
+++ b/src/AutoRace.Infrastructure/AutoRace.Infrastructure.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoRace.Core\AutoRace.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/AutoRace.Infrastructure/Class1.cs
+++ b/src/AutoRace.Infrastructure/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace AutoRace.Infrastructure;
+
+public class Class1
+{
+
+}

--- a/src/AutoRace.sln
+++ b/src/AutoRace.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.App", "AutoRace.App\AutoRace.App.csproj", "{6D5AF56A-FCE4-4A0E-B99F-365CE4D41B46}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.Core", "AutoRace.Core\AutoRace.Core.csproj", "{1D659838-9865-42BB-8B82-3BE3A797AF06}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.Infrastructure", "AutoRace.Infrastructure\AutoRace.Infrastructure.csproj", "{951748FB-43E8-4426-B905-051F32D12226}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6D5AF56A-FCE4-4A0E-B99F-365CE4D41B46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D5AF56A-FCE4-4A0E-B99F-365CE4D41B46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D5AF56A-FCE4-4A0E-B99F-365CE4D41B46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D5AF56A-FCE4-4A0E-B99F-365CE4D41B46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D659838-9865-42BB-8B82-3BE3A797AF06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D659838-9865-42BB-8B82-3BE3A797AF06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D659838-9865-42BB-8B82-3BE3A797AF06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D659838-9865-42BB-8B82-3BE3A797AF06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{951748FB-43E8-4426-B905-051F32D12226}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{951748FB-43E8-4426-B905-051F32D12226}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{951748FB-43E8-4426-B905-051F32D12226}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{951748FB-43E8-4426-B905-051F32D12226}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Implements Issue #13 (new src structure) and starts #16 (CI).

What's included:
- src/AutoRace.sln
- AutoRace.Core (net8.0)
- AutoRace.Infrastructure (net8.0) -> references Core
- AutoRace.App (WPF, net8.0-windows) -> references Core + Infrastructure
- GitHub Actions (windows-latest) building src solution

Next:
- replace placeholder Class1
- migrate WinAPI/input/pixel helpers into Infrastructure
- build MVVM ViewModels/Services

Closes #13
