### PR TITLE
Core: add initial domain models (profiles + run state)

### DIFF
--- a/src/AutoRace.Core/Class1.cs
+++ b/src/AutoRace.Core/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace AutoRace.Core;
-
-public class Class1
-{
-
-}

--- a/src/AutoRace.Core/Domain/Models/Profile.cs
+++ b/src/AutoRace.Core/Domain/Models/Profile.cs
@@ -1,0 +1,21 @@
+namespace AutoRace.Core.Domain.Models;
+
+/// <summary>
+/// A user-configurable configuration for running AutoRace.
+/// Keep this small and stable; UI/services can expand it later.
+/// </summary>
+public sealed record Profile(
+    string Name,
+    ProfileSettings Settings);
+
+public sealed record ProfileSettings(
+    /// <summary>
+    /// Human-friendly identifier for which game/window this profile targets.
+    /// (e.g., window title substring)
+    /// </summary>
+    string TargetWindow,
+
+    /// <summary>
+    /// Optional notes for the user.
+    /// </summary>
+    string? Notes = null);

--- a/src/AutoRace.Core/Domain/Models/RunState.cs
+++ b/src/AutoRace.Core/Domain/Models/RunState.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace AutoRace.Core.Domain.Models;
+
+/// <summary>
+/// Represents the current state of an automation run.
+/// </summary>
+public sealed record RunState(
+    RunStatus Status,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? StoppedAt,
+    string? LastMessage = null)
+{
+    public static RunState Idle(string? message = null)
+        => new(RunStatus.Idle, DateTimeOffset.MinValue, null, message);
+
+    public static RunState Running(DateTimeOffset startedAt, string? message = null)
+        => new(RunStatus.Running, startedAt, null, message);
+
+    public static RunState Stopped(DateTimeOffset startedAt, DateTimeOffset stoppedAt, string? message = null)
+        => new(RunStatus.Stopped, startedAt, stoppedAt, message);
+}
+
+public enum RunStatus
+{
+    Idle = 0,
+    Running = 1,
+    Stopped = 2,
+    Faulted = 3,
+}


### PR DESCRIPTION
Adds a minimal set of domain models in AutoRace.Core for Profiles and RunState, to unblock Core/service extraction work.

Closes #20.