### PR TITLE
core: add domain models + validation (issue #2)

### DIFF
--- a/src/AutoRace.Core.Tests/AutoRace.Core.Tests.csproj
+++ b/src/AutoRace.Core.Tests/AutoRace.Core.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoRace.Core\AutoRace.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AutoRace.Core.Tests/DomainValidationTests.cs
+++ b/src/AutoRace.Core.Tests/DomainValidationTests.cs
@@ -1,0 +1,96 @@
+using AutoRace.Core.Domain.Models;
+using AutoRace.Core.Domain.Validation;
+
+namespace AutoRace.Core.Tests;
+
+public sealed class DomainValidationTests
+{
+    [Fact]
+    public void Profile_Name_Is_Required_And_Bounded()
+    {
+        var settings = new ProfileSettings("Game Window");
+
+        var emptyName = new Profile("", settings);
+        Assert.NotEmpty(DomainValidation.Validate(emptyName));
+
+        var whitespaceName = new Profile("   ", settings);
+        Assert.NotEmpty(DomainValidation.Validate(whitespaceName));
+
+        var tooLongName = new Profile(new string('a', 65), settings);
+        Assert.NotEmpty(DomainValidation.Validate(tooLongName));
+
+        var validName = new Profile(new string('a', 64), settings);
+        Assert.Empty(DomainValidation.Validate(validName));
+    }
+
+    [Fact]
+    public void ProfileSettings_TargetWindow_Is_Required_And_Bounded()
+    {
+        var empty = new ProfileSettings("");
+        Assert.NotEmpty(DomainValidation.Validate(empty));
+
+        var whitespace = new ProfileSettings("   ");
+        Assert.NotEmpty(DomainValidation.Validate(whitespace));
+
+        var tooLong = new ProfileSettings(new string('b', 129));
+        Assert.NotEmpty(DomainValidation.Validate(tooLong));
+
+        var valid = new ProfileSettings(new string('b', 128));
+        Assert.Empty(DomainValidation.Validate(valid));
+    }
+
+    [Fact]
+    public void KeyBinding_Requires_Key_And_Modifiers_Are_Not_Whitespace()
+    {
+        var emptyKey = new KeyBinding("");
+        Assert.NotEmpty(DomainValidation.Validate(emptyKey));
+
+        var whitespaceKey = new KeyBinding("   ");
+        Assert.NotEmpty(DomainValidation.Validate(whitespaceKey));
+
+        var invalidModifier = new KeyBinding("K", new[] { " " });
+        Assert.NotEmpty(DomainValidation.Validate(invalidModifier));
+
+        var valid = new KeyBinding("K", new[] { "Ctrl", "Shift" });
+        Assert.Empty(DomainValidation.Validate(valid));
+    }
+
+    [Fact]
+    public void TimingProfile_Durations_Must_Be_NonNegative_And_Reasonable()
+    {
+        var negative = new TimingProfile(TimeSpan.FromSeconds(-1));
+        Assert.NotEmpty(DomainValidation.Validate(negative));
+
+        var tooLong = new TimingProfile(TimeSpan.FromMinutes(10));
+        Assert.NotEmpty(DomainValidation.Validate(tooLong));
+
+        var valid = new TimingProfile(TimeSpan.FromMinutes(9));
+        Assert.Empty(DomainValidation.Validate(valid));
+    }
+
+    [Fact]
+    public void DetectionRule_Requires_Name_And_Threshold_Between_Zero_And_One()
+    {
+        var missingName = new DetectionRule("", 0.5);
+        Assert.NotEmpty(DomainValidation.Validate(missingName));
+
+        var low = new DetectionRule("Rule", -0.1);
+        Assert.NotEmpty(DomainValidation.Validate(low));
+
+        var high = new DetectionRule("Rule", 1.1);
+        Assert.NotEmpty(DomainValidation.Validate(high));
+
+        var validMin = new DetectionRule("Rule", 0);
+        Assert.Empty(DomainValidation.Validate(validMin));
+
+        var validMax = new DetectionRule("Rule", 1);
+        Assert.Empty(DomainValidation.Validate(validMax));
+    }
+
+    [Fact]
+    public void ValidateOrThrow_Throws_With_Errors()
+    {
+        var profile = new Profile("", new ProfileSettings("Game Window"));
+        Assert.Throws<DomainValidationException>(() => DomainValidation.ValidateOrThrow(profile));
+    }
+}

--- a/src/AutoRace.Core.Tests/Usings.cs
+++ b/src/AutoRace.Core.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/AutoRace.Core/Domain/Models/DetectionRule.cs
+++ b/src/AutoRace.Core/Domain/Models/DetectionRule.cs
@@ -1,0 +1,8 @@
+namespace AutoRace.Core.Domain.Models;
+
+/// <summary>
+/// Represents a rule used to detect a condition during automation.
+/// </summary>
+public sealed record DetectionRule(
+    string Name,
+    double Threshold = 0.5);

--- a/src/AutoRace.Core/Domain/Models/KeyBinding.cs
+++ b/src/AutoRace.Core/Domain/Models/KeyBinding.cs
@@ -1,0 +1,8 @@
+namespace AutoRace.Core.Domain.Models;
+
+/// <summary>
+/// Represents a key with optional modifier keys.
+/// </summary>
+public sealed record KeyBinding(
+    string Key,
+    IReadOnlyList<string>? Modifiers = null);

--- a/src/AutoRace.Core/Domain/Models/Profile.cs
+++ b/src/AutoRace.Core/Domain/Models/Profile.cs
@@ -8,14 +8,45 @@ public sealed record Profile(
     string Name,
     ProfileSettings Settings);
 
-public sealed record ProfileSettings(
+public sealed record ProfileSettings
+{
     /// <summary>
     /// Human-friendly identifier for which game/window this profile targets.
     /// (e.g., window title substring)
     /// </summary>
-    string TargetWindow,
+    public string TargetWindow { get; init; }
 
     /// <summary>
     /// Optional notes for the user.
     /// </summary>
-    string? Notes = null);
+    public string? Notes { get; init; }
+
+    /// <summary>
+    /// Optional rules used to detect automation conditions.
+    /// </summary>
+    public IReadOnlyList<DetectionRule> DetectionRules { get; init; }
+
+    /// <summary>
+    /// Optional key binding used to start/stop automation.
+    /// </summary>
+    public KeyBinding? ActivationKey { get; init; }
+
+    /// <summary>
+    /// Timing configuration.
+    /// </summary>
+    public TimingProfile Timing { get; init; }
+
+    public ProfileSettings(
+        string targetWindow,
+        string? notes = null,
+        IReadOnlyList<DetectionRule>? detectionRules = null,
+        KeyBinding? activationKey = null,
+        TimingProfile? timing = null)
+    {
+        TargetWindow = targetWindow;
+        Notes = notes;
+        DetectionRules = detectionRules ?? Array.Empty<DetectionRule>();
+        ActivationKey = activationKey;
+        Timing = timing ?? new TimingProfile();
+    }
+}

--- a/src/AutoRace.Core/Domain/Models/TimingProfile.cs
+++ b/src/AutoRace.Core/Domain/Models/TimingProfile.cs
@@ -1,0 +1,9 @@
+namespace AutoRace.Core.Domain.Models;
+
+/// <summary>
+/// Timing configuration for delays during automation.
+/// </summary>
+public sealed record TimingProfile(
+    TimeSpan PreStartDelay = default,
+    TimeSpan BetweenActionsDelay = default,
+    TimeSpan PostStopDelay = default);

--- a/src/AutoRace.Core/Domain/Validation/DomainValidation.cs
+++ b/src/AutoRace.Core/Domain/Validation/DomainValidation.cs
@@ -1,0 +1,196 @@
+using AutoRace.Core.Domain.Models;
+
+namespace AutoRace.Core.Domain.Validation;
+
+public static class DomainValidation
+{
+    private const int ProfileNameMaxLength = 64;
+    private const int TargetWindowMaxLength = 128;
+    private static readonly TimeSpan MaxTimingDuration = TimeSpan.FromMinutes(10);
+
+    public static IReadOnlyList<string> Validate(Profile? profile)
+    {
+        var errors = new List<string>();
+
+        if (profile is null)
+        {
+            errors.Add("Profile is required.");
+            return errors;
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Name))
+        {
+            errors.Add("Profile name is required.");
+        }
+        else if (profile.Name.Length > ProfileNameMaxLength)
+        {
+            errors.Add($"Profile name must be 1-{ProfileNameMaxLength} characters.");
+        }
+
+        errors.AddRange(Validate(profile.Settings));
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> Validate(ProfileSettings? settings)
+    {
+        var errors = new List<string>();
+
+        if (settings is null)
+        {
+            errors.Add("Profile settings are required.");
+            return errors;
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.TargetWindow))
+        {
+            errors.Add("Target window is required.");
+        }
+        else if (settings.TargetWindow.Length > TargetWindowMaxLength)
+        {
+            errors.Add($"Target window must be 1-{TargetWindowMaxLength} characters.");
+        }
+
+        if (settings.DetectionRules is not null)
+        {
+            for (var i = 0; i < settings.DetectionRules.Count; i++)
+            {
+                var rule = settings.DetectionRules[i];
+                if (rule is null)
+                {
+                    errors.Add($"Detection rule at index {i} is required.");
+                    continue;
+                }
+
+                foreach (var error in Validate(rule))
+                {
+                    errors.Add($"Detection rule at index {i}: {error}");
+                }
+            }
+        }
+
+        if (settings.ActivationKey is not null)
+        {
+            foreach (var error in Validate(settings.ActivationKey))
+            {
+                errors.Add($"Activation key: {error}");
+            }
+        }
+
+        if (settings.Timing is not null)
+        {
+            foreach (var error in Validate(settings.Timing))
+            {
+                errors.Add($"Timing: {error}");
+            }
+        }
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> Validate(KeyBinding? keyBinding)
+    {
+        var errors = new List<string>();
+
+        if (keyBinding is null)
+        {
+            errors.Add("Key binding is required.");
+            return errors;
+        }
+
+        if (string.IsNullOrWhiteSpace(keyBinding.Key))
+        {
+            errors.Add("Key is required.");
+        }
+
+        if (keyBinding.Modifiers is not null)
+        {
+            for (var i = 0; i < keyBinding.Modifiers.Count; i++)
+            {
+                if (string.IsNullOrWhiteSpace(keyBinding.Modifiers[i]))
+                {
+                    errors.Add($"Modifier at index {i} is required.");
+                }
+            }
+        }
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> Validate(TimingProfile? timingProfile)
+    {
+        var errors = new List<string>();
+
+        if (timingProfile is null)
+        {
+            errors.Add("Timing profile is required.");
+            return errors;
+        }
+
+        ValidateDuration(timingProfile.PreStartDelay, "Pre-start delay", errors);
+        ValidateDuration(timingProfile.BetweenActionsDelay, "Between-actions delay", errors);
+        ValidateDuration(timingProfile.PostStopDelay, "Post-stop delay", errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> Validate(DetectionRule? detectionRule)
+    {
+        var errors = new List<string>();
+
+        if (detectionRule is null)
+        {
+            errors.Add("Detection rule is required.");
+            return errors;
+        }
+
+        if (string.IsNullOrWhiteSpace(detectionRule.Name))
+        {
+            errors.Add("Name is required.");
+        }
+
+        if (detectionRule.Threshold < 0 || detectionRule.Threshold > 1)
+        {
+            errors.Add("Threshold must be between 0 and 1.");
+        }
+
+        return errors;
+    }
+
+    public static void ValidateOrThrow(Profile? profile)
+        => ThrowIfInvalid(Validate(profile));
+
+    public static void ValidateOrThrow(ProfileSettings? settings)
+        => ThrowIfInvalid(Validate(settings));
+
+    public static void ValidateOrThrow(KeyBinding? keyBinding)
+        => ThrowIfInvalid(Validate(keyBinding));
+
+    public static void ValidateOrThrow(TimingProfile? timingProfile)
+        => ThrowIfInvalid(Validate(timingProfile));
+
+    public static void ValidateOrThrow(DetectionRule? detectionRule)
+        => ThrowIfInvalid(Validate(detectionRule));
+
+    private static void ValidateDuration(TimeSpan duration, string name, ICollection<string> errors)
+    {
+        if (duration < TimeSpan.Zero)
+        {
+            errors.Add($"{name} must be non-negative.");
+            return;
+        }
+
+        if (duration >= MaxTimingDuration)
+        {
+            errors.Add($"{name} must be less than {MaxTimingDuration.TotalMinutes:0} minutes.");
+        }
+    }
+
+    private static void ThrowIfInvalid(IReadOnlyList<string> errors)
+    {
+        if (errors.Count > 0)
+        {
+            throw new DomainValidationException(errors);
+        }
+    }
+}

--- a/src/AutoRace.Core/Domain/Validation/DomainValidationException.cs
+++ b/src/AutoRace.Core/Domain/Validation/DomainValidationException.cs
@@ -1,0 +1,12 @@
+namespace AutoRace.Core.Domain.Validation;
+
+public sealed class DomainValidationException : Exception
+{
+    public DomainValidationException(IReadOnlyList<string> errors)
+        : base("Domain validation failed.")
+    {
+        Errors = errors;
+    }
+
+    public IReadOnlyList<string> Errors { get; }
+}

--- a/src/AutoRace.sln
+++ b/src/AutoRace.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.Core", "AutoRace.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.Infrastructure", "AutoRace.Infrastructure\AutoRace.Infrastructure.csproj", "{951748FB-43E8-4426-B905-051F32D12226}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRace.Core.Tests", "AutoRace.Core.Tests\AutoRace.Core.Tests.csproj", "{90AC61F4-1A33-4042-98B7-472BCF2090B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{951748FB-43E8-4426-B905-051F32D12226}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{951748FB-43E8-4426-B905-051F32D12226}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{951748FB-43E8-4426-B905-051F32D12226}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90AC61F4-1A33-4042-98B7-472BCF2090B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90AC61F4-1A33-4042-98B7-472BCF2090B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90AC61F4-1A33-4042-98B7-472BCF2090B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90AC61F4-1A33-4042-98B7-472BCF2090B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Implements core domain model scaffolding for #2.

Changes:
- Add domain records: DetectionRule, KeyBinding, TimingProfile
- Expand ProfileSettings to include detection rules, activation key, and timing (with sensible defaults)
- Add DomainValidation + DomainValidationException
- Add xUnit test project AutoRace.Core.Tests and validation tests

Notes:
- Core-only (no UI/WinAPI/infra deps)
