### PR TITLE
infra: Win32 keyboard input abstraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,8 @@ jobs:
 
       - name: Build
         run: dotnet build src/AutoRace.sln -c Release --no-restore
+
+      - name: Test
+        shell: pwsh
+        run: |
+          dotnet test src/AutoRace.sln -c Release --no-build

--- a/src/AutoRace.Core/Input/IKeyboardInput.cs
+++ b/src/AutoRace.Core/Input/IKeyboardInput.cs
@@ -1,0 +1,70 @@
+namespace AutoRace.Core.Input;
+
+public interface IKeyboardInput
+{
+    void KeyDown(ScanCode key);
+    void KeyUp(ScanCode key);
+    void Press(ScanCode key);
+}
+
+/// <summary>
+/// Minimal set of keyboard scan codes (Set 1) used by AutoRace.
+/// Values match legacy Eco_Lib ScanCodeShort for compatibility.
+/// </summary>
+public enum ScanCode : ushort
+{
+    Escape = 0x01,
+
+    Digit1 = 0x02,
+    Digit2 = 0x03,
+    Digit3 = 0x04,
+    Digit4 = 0x05,
+    Digit5 = 0x06,
+    Digit6 = 0x07,
+    Digit7 = 0x08,
+    Digit8 = 0x09,
+    Digit9 = 0x0A,
+    Digit0 = 0x0B,
+
+    Q = 0x10,
+    W = 0x11,
+    E = 0x12,
+    R = 0x13,
+    T = 0x14,
+    Y = 0x15,
+    U = 0x16,
+    I = 0x17,
+    O = 0x18,
+    P = 0x19,
+
+    Enter = 0x1C,
+    LeftControl = 0x1D,
+
+    A = 0x1E,
+    S = 0x1F,
+    D = 0x20,
+    F = 0x21,
+    G = 0x22,
+    H = 0x23,
+    J = 0x24,
+    K = 0x25,
+    L = 0x26,
+
+    LeftShift = 0x2A,
+
+    Z = 0x2C,
+    X = 0x2D,
+    C = 0x2E,
+    V = 0x2F,
+    B = 0x30,
+    N = 0x31,
+    M = 0x32,
+
+    LeftAlt = 0x38,
+    Space = 0x39,
+
+    Up = 0x48,
+    Left = 0x4B,
+    Right = 0x4D,
+    Down = 0x50
+}

--- a/src/AutoRace.Infrastructure/Class1.cs
+++ b/src/AutoRace.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace AutoRace.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/src/AutoRace.Infrastructure/Input/Win32KeyboardInput.cs
+++ b/src/AutoRace.Infrastructure/Input/Win32KeyboardInput.cs
@@ -1,0 +1,93 @@
+using System.Runtime.InteropServices;
+using AutoRace.Core.Input;
+
+namespace AutoRace.Infrastructure.Input;
+
+public sealed class Win32KeyboardInput : IKeyboardInput
+{
+    public void KeyDown(ScanCode key) => Send(key, isKeyUp: false);
+
+    public void KeyUp(ScanCode key) => Send(key, isKeyUp: true);
+
+    public void Press(ScanCode key)
+    {
+        KeyDown(key);
+        KeyUp(key);
+    }
+
+    private static void Send(ScanCode key, bool isKeyUp)
+    {
+        var flags = KeyEventF.Scancode;
+
+        if (isKeyUp)
+        {
+            flags |= KeyEventF.KeyUp;
+        }
+
+        // Arrow keys are "extended".
+        if (key is ScanCode.Up or ScanCode.Down or ScanCode.Left or ScanCode.Right)
+        {
+            flags |= KeyEventF.ExtendedKey;
+        }
+
+        INPUT[] inputs =
+        [
+            new INPUT
+            {
+                type = InputType.Keyboard,
+                U = new InputUnion
+                {
+                    ki = new KEYBDINPUT
+                    {
+                        wVk = 0,
+                        wScan = (ushort)key,
+                        dwFlags = flags,
+                        time = 0,
+                        dwExtraInfo = UIntPtr.Zero
+                    }
+                }
+            }
+        ];
+
+        _ = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+    }
+
+    private enum InputType : uint
+    {
+        Keyboard = 1
+    }
+
+    [Flags]
+    private enum KeyEventF : uint
+    {
+        ExtendedKey = 0x0001,
+        KeyUp = 0x0002,
+        Scancode = 0x0008
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public InputType type;
+        public InputUnion U;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)] public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public KeyEventF dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+}


### PR DESCRIPTION
Addresses part of #15 and #5 by extracting the Win32 SendInput keyboard helper from legacy Eco_Lib into the new src projects.

Changes:
- AutoRace.Core: add IKeyboardInput + minimal ScanCode enum (Set 1 scan codes)
- AutoRace.Infrastructure: add Win32KeyboardInput (SendInput P/Invoke)
- Remove placeholder AutoRace.Infrastructure/Class1.cs
- CI: add dotnet test step to existing Windows workflow

Notes:
- Legacy Eco_Lib is untouched; this is a small forward-looking extraction to Infrastructure.
