### PR TITLE
feat(core): minimal AutomationEngine w/ cancellation + event stream

### DIFF
--- a/src/AutoRace.Core.Tests/AutomationEngineTests.cs
+++ b/src/AutoRace.Core.Tests/AutomationEngineTests.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using AutoRace.Core.Automation;
+using AutoRace.Core.Domain.Models;
+
+namespace AutoRace.Core.Tests;
+
+public sealed class AutomationEngineTests
+{
+    private static Profile CreateProfile(string name = "Test")
+        => new(name, new ProfileSettings("Game Window"));
+
+    [Fact]
+    public async Task Start_Then_Stop_Emits_Started_And_Stopped()
+    {
+        using var engine = new AutomationEngine(ct => Task.Delay(10, ct));
+
+        await engine.StartAsync(CreateProfile());
+
+        var started = await ReadNextAsync(engine, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Started, started.Kind);
+
+        await engine.StopAsync();
+
+        // There may be progress events in between; scan until Stopped.
+        var stopped = await ReadUntilAsync(engine, AutomationEventKind.Stopped, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Stopped, stopped.Kind);
+    }
+
+    [Fact]
+    public async Task Stop_Completes_Within_500ms()
+    {
+        using var engine = new AutomationEngine(ct => Task.Delay(50, ct));
+        await engine.StartAsync(CreateProfile());
+
+        // consume Started so the loop is definitely running
+        _ = await ReadNextAsync(engine, TimeSpan.FromSeconds(1));
+
+        var sw = Stopwatch.StartNew();
+        await engine.StopAsync();
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(500), $"Stop took {sw.Elapsed.TotalMilliseconds:0}ms");
+    }
+
+    [Fact]
+    public async Task Faulted_Event_Is_Emitted_On_Exception()
+    {
+        var thrown = new InvalidOperationException("boom");
+        using var engine = new AutomationEngine(_ => throw thrown);
+
+        await engine.StartAsync(CreateProfile());
+
+        // Started should still be emitted before fault.
+        var started = await ReadNextAsync(engine, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Started, started.Kind);
+
+        var faulted = await ReadUntilAsync(engine, AutomationEventKind.Faulted, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Faulted, faulted.Kind);
+        Assert.IsType<InvalidOperationException>(faulted.Exception);
+
+        var stopped = await ReadUntilAsync(engine, AutomationEventKind.Stopped, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Stopped, stopped.Kind);
+    }
+
+    private static async Task<AutomationEvent> ReadNextAsync(IAutomationEngine engine, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        return await engine.Events.ReadAsync(cts.Token);
+    }
+
+    private static async Task<AutomationEvent> ReadUntilAsync(IAutomationEngine engine, AutomationEventKind kind, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero) break;
+
+            var next = await ReadNextAsync(engine, remaining);
+            if (next.Kind == kind)
+            {
+                return next;
+            }
+        }
+
+        throw new TimeoutException($"Did not observe event kind '{kind}' within {timeout}.");
+    }
+}

--- a/src/AutoRace.Core.Tests/AutomationEngineTests.cs
+++ b/src/AutoRace.Core.Tests/AutomationEngineTests.cs
@@ -62,6 +62,23 @@ public sealed class AutomationEngineTests
         Assert.Equal(AutomationEventKind.Stopped, stopped.Kind);
     }
 
+    [Fact]
+    public async Task Start_Stop_Start_Emits_Second_Started()
+    {
+        using var engine = new AutomationEngine(ct => Task.Delay(10, ct));
+
+        await engine.StartAsync(CreateProfile("First"));
+        _ = await ReadUntilAsync(engine, AutomationEventKind.Started, TimeSpan.FromSeconds(1));
+
+        await engine.StopAsync();
+        _ = await ReadUntilAsync(engine, AutomationEventKind.Stopped, TimeSpan.FromSeconds(1));
+
+        await engine.StartAsync(CreateProfile("Second"));
+
+        var restarted = await ReadUntilAsync(engine, AutomationEventKind.Started, TimeSpan.FromSeconds(1));
+        Assert.Equal(AutomationEventKind.Started, restarted.Kind);
+    }
+
     private static async Task<AutomationEvent> ReadNextAsync(IAutomationEngine engine, TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);

--- a/src/AutoRace.Core/AutoRace.Core.csproj
+++ b/src/AutoRace.Core/AutoRace.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/AutoRace.Core/Automation/AutomationEngine.cs
+++ b/src/AutoRace.Core/Automation/AutomationEngine.cs
@@ -1,0 +1,131 @@
+using System.Threading.Channels;
+using AutoRace.Core.Domain.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AutoRace.Core.Automation;
+
+public sealed class AutomationEngine : IAutomationEngine, IDisposable
+{
+    private readonly ILogger<AutomationEngine> _logger;
+    private readonly Func<CancellationToken, Task> _step;
+    private readonly Channel<AutomationEvent> _events;
+    private readonly object _gate = new();
+
+    private CancellationTokenSource? _cts;
+    private Task? _runTask;
+    private int _progress;
+
+    public ChannelReader<AutomationEvent> Events => _events.Reader;
+
+    public AutomationEngine(
+        Func<CancellationToken, Task>? step = null,
+        ILogger<AutomationEngine>? logger = null)
+    {
+        _logger = logger ?? NullLogger<AutomationEngine>.Instance;
+        _step = step ?? (ct => Task.Delay(TimeSpan.FromMilliseconds(50), ct));
+        _events = Channel.CreateUnbounded<AutomationEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = true,
+            AllowSynchronousContinuations = true,
+        });
+    }
+
+    public Task StartAsync(Profile profile, CancellationToken cancellationToken = default)
+    {
+        if (profile is null) throw new ArgumentNullException(nameof(profile));
+
+        lock (_gate)
+        {
+            if (_runTask is not null && !_runTask.IsCompleted)
+            {
+                throw new InvalidOperationException("Automation engine is already running.");
+            }
+
+            _progress = 0;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            _runTask = RunAsync(profile, _cts.Token);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        Task? runTask;
+        CancellationTokenSource? cts;
+
+        lock (_gate)
+        {
+            runTask = _runTask;
+            cts = _cts;
+        }
+
+        if (runTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // ignore
+        }
+
+        // Await completion but keep it bounded by external cancellation if provided.
+        await runTask.WaitAsync(cancellationToken);
+    }
+
+    private async Task RunAsync(Profile profile, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await PublishAsync(new AutomationEvent(AutomationEventKind.Started, DateTimeOffset.UtcNow, Message: profile.Name), cancellationToken);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await _step(cancellationToken);
+                _progress++;
+                await PublishAsync(new AutomationEvent(AutomationEventKind.Progress, DateTimeOffset.UtcNow, Progress: _progress), cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // expected
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Automation loop faulted");
+            await PublishAsync(new AutomationEvent(AutomationEventKind.Faulted, DateTimeOffset.UtcNow, Exception: ex), CancellationToken.None);
+        }
+        finally
+        {
+            await PublishAsync(new AutomationEvent(AutomationEventKind.Stopped, DateTimeOffset.UtcNow), CancellationToken.None);
+            _events.Writer.TryComplete();
+
+            lock (_gate)
+            {
+                _cts?.Dispose();
+                _cts = null;
+            }
+        }
+    }
+
+    private ValueTask PublishAsync(AutomationEvent evt, CancellationToken cancellationToken)
+        => _events.Writer.WriteAsync(evt, cancellationToken);
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+}

--- a/src/AutoRace.Core/Automation/AutomationEvent.cs
+++ b/src/AutoRace.Core/Automation/AutomationEvent.cs
@@ -1,0 +1,16 @@
+namespace AutoRace.Core.Automation;
+
+public enum AutomationEventKind
+{
+    Started,
+    Progress,
+    Stopped,
+    Faulted,
+}
+
+public sealed record AutomationEvent(
+    AutomationEventKind Kind,
+    DateTimeOffset At,
+    string? Message = null,
+    int? Progress = null,
+    Exception? Exception = null);

--- a/src/AutoRace.Core/Automation/IAutomationEngine.cs
+++ b/src/AutoRace.Core/Automation/IAutomationEngine.cs
@@ -1,0 +1,13 @@
+using System.Threading.Channels;
+using AutoRace.Core.Domain.Models;
+
+namespace AutoRace.Core.Automation;
+
+public interface IAutomationEngine
+{
+    ChannelReader<AutomationEvent> Events { get; }
+
+    Task StartAsync(Profile profile, CancellationToken cancellationToken = default);
+
+    Task StopAsync(CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
Implements a minimal Core "AutomationEngine" to start/stop with CancellationToken and emit an event stream (ChannelReader).

- Adds AutoRace.Core/Automation/* (IAutomationEngine, AutomationEngine, AutomationEvent)
- Adds logging via Microsoft.Extensions.Logging.Abstractions
- Adds unit tests for started/stopped, stop latency (<500ms), and faulted events

Closes #3.