### PR TITLE
feat(ui): OverlayInfoWindow with live runtime stats

### DIFF
--- a/src/AutoRace.App/MainWindow.xaml.cs
+++ b/src/AutoRace.App/MainWindow.xaml.cs
@@ -1,13 +1,6 @@
-﻿using System.Text;
+using System.ComponentModel;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using AutoRace.App.ViewModels;
 
 namespace AutoRace.App;
 
@@ -16,8 +9,76 @@ namespace AutoRace.App;
 /// </summary>
 public partial class MainWindow : Window
 {
+    private readonly OverlayInfoWindow _overlayWindow;
+    private readonly OverlayInfoViewModel _overlayVm;
+
     public MainWindow()
     {
         InitializeComponent();
+
+        _overlayVm = new OverlayInfoViewModel();
+        _overlayWindow = new OverlayInfoWindow
+        {
+            DataContext = _overlayVm,
+            Owner = this
+        };
+
+        Loaded += (_, _) => HookViewModel();
+        Closing += (_, _) =>
+        {
+            try { _overlayWindow.Close(); } catch { /* ignore */ }
+        };
+    }
+
+    private void HookViewModel()
+    {
+        if (DataContext is not MainViewModel vm) return;
+
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(MainViewModel.IsRunning))
+            {
+                if (vm.IsRunning) ShowOverlay(vm);
+                else HideOverlay();
+            }
+
+            if (e.PropertyName is nameof(MainViewModel.StatusText)
+                or nameof(MainViewModel.ElapsedText)
+                or nameof(MainViewModel.Rounds)
+                or nameof(MainViewModel.Revenue))
+            {
+                SyncOverlay(vm);
+            }
+        };
+
+        SyncOverlay(vm);
+        if (vm.IsRunning) ShowOverlay(vm);
+    }
+
+    private void ShowOverlay(MainViewModel vm)
+    {
+        SyncOverlay(vm);
+
+        if (_overlayWindow.IsVisible)
+        {
+            _overlayWindow.Activate();
+            return;
+        }
+
+        _overlayWindow.Show();
+    }
+
+    private void HideOverlay()
+    {
+        if (!_overlayWindow.IsVisible) return;
+        _overlayWindow.Hide();
+    }
+
+    private void SyncOverlay(MainViewModel vm)
+    {
+        _overlayVm.StatusText = vm.StatusText;
+        _overlayVm.ElapsedText = vm.ElapsedText;
+        _overlayVm.Rounds = vm.Rounds;
+        _overlayVm.Revenue = vm.Revenue;
     }
 }

--- a/src/AutoRace.App/OverlayInfoWindow.xaml
+++ b/src/AutoRace.App/OverlayInfoWindow.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="AutoRace.App.OverlayInfoWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Overlay"
+        Width="240" Height="110"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        Topmost="True"
+        ShowInTaskbar="False"
+        AllowsTransparency="True"
+        Background="Transparent">
+
+    <Border Background="#CC111111" CornerRadius="10" Padding="10" BorderBrush="#33000000" BorderThickness="1">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Status" Foreground="#CCFFFFFF" FontWeight="SemiBold" />
+            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding StatusText}" Foreground="#FFFFFFFF" Margin="10,0,0,0" TextTrimming="CharacterEllipsis" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Elapsed" Foreground="#CCFFFFFF" FontWeight="SemiBold" Margin="0,6,0,0" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ElapsedText}" Foreground="#FFFFFFFF" Margin="10,6,0,0" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Rounds" Foreground="#CCFFFFFF" FontWeight="SemiBold" Margin="0,6,0,0" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Rounds}" Foreground="#FFFFFFFF" Margin="10,6,0,0" />
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Revenue" Foreground="#CCFFFFFF" FontWeight="SemiBold" Margin="0,6,0,0" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding RevenueText}" Foreground="#FFFFFFFF" Margin="10,6,0,0" />
+        </Grid>
+    </Border>
+</Window>

--- a/src/AutoRace.App/OverlayInfoWindow.xaml
+++ b/src/AutoRace.App/OverlayInfoWindow.xaml
@@ -9,6 +9,8 @@
         WindowStyle="None"
         ResizeMode="NoResize"
         Topmost="True"
+        ShowActivated="False"
+        Focusable="False"
         ShowInTaskbar="False"
         AllowsTransparency="True"
         Background="Transparent">

--- a/src/AutoRace.App/OverlayInfoWindow.xaml.cs
+++ b/src/AutoRace.App/OverlayInfoWindow.xaml.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using System.Windows.Input;
+using AutoRace.App.Services;
+
+namespace AutoRace.App;
+
+public partial class OverlayInfoWindow : Window
+{
+    private readonly OverlaySettings _settings;
+
+    public OverlayInfoWindow()
+    {
+        InitializeComponent();
+
+        _settings = OverlaySettings.Load();
+        Loaded += OnLoaded;
+        LocationChanged += (_, _) => SavePosition();
+        Closed += (_, _) => SavePosition();
+
+        MouseLeftButtonDown += (_, e) =>
+        {
+            if (e.ButtonState != MouseButtonState.Pressed) return;
+            try
+            {
+                DragMove();
+            }
+            catch
+            {
+                // ignore
+            }
+            SavePosition();
+        };
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_settings.Left is double left) Left = left;
+        if (_settings.Top is double top) Top = top;
+    }
+
+    private void SavePosition()
+    {
+        _settings.Left = Left;
+        _settings.Top = Top;
+        _settings.Save();
+    }
+}

--- a/src/AutoRace.App/OverlayInfoWindow.xaml.cs
+++ b/src/AutoRace.App/OverlayInfoWindow.xaml.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 using AutoRace.App.Services;
 
 namespace AutoRace.App;
@@ -7,15 +9,27 @@ namespace AutoRace.App;
 public partial class OverlayInfoWindow : Window
 {
     private readonly OverlaySettings _settings;
+    private readonly DispatcherTimer _saveDebounce;
 
     public OverlayInfoWindow()
     {
         InitializeComponent();
 
         _settings = OverlaySettings.Load();
+
+        _saveDebounce = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(500)
+        };
+        _saveDebounce.Tick += (_, _) =>
+        {
+            _saveDebounce.Stop();
+            SavePositionCore();
+        };
+
         Loaded += OnLoaded;
-        LocationChanged += (_, _) => SavePosition();
-        Closed += (_, _) => SavePosition();
+        LocationChanged += (_, _) => ScheduleSavePosition();
+        Closed += (_, _) => SavePositionCore();
 
         MouseLeftButtonDown += (_, e) =>
         {
@@ -28,7 +42,7 @@ public partial class OverlayInfoWindow : Window
             {
                 // ignore
             }
-            SavePosition();
+            ScheduleSavePosition();
         };
     }
 
@@ -36,9 +50,40 @@ public partial class OverlayInfoWindow : Window
     {
         if (_settings.Left is double left) Left = left;
         if (_settings.Top is double top) Top = top;
+
+        ClampToWorkArea();
     }
 
-    private void SavePosition()
+    private void ClampToWorkArea()
+    {
+        // Prevent the overlay from restoring off-screen (e.g., monitor config changes).
+        var wa = SystemParameters.WorkArea;
+
+        if (double.IsNaN(Left) || double.IsInfinity(Left)) Left = wa.Left;
+        if (double.IsNaN(Top) || double.IsInfinity(Top)) Top = wa.Top;
+
+        var maxLeft = wa.Right - ActualWidth;
+        var maxTop = wa.Bottom - ActualHeight;
+
+        if (ActualWidth <= 0) maxLeft = wa.Right - Width;
+        if (ActualHeight <= 0) maxTop = wa.Bottom - Height;
+
+        if (Left < wa.Left) Left = wa.Left;
+        else if (Left > maxLeft) Left = maxLeft;
+
+        if (Top < wa.Top) Top = wa.Top;
+        else if (Top > maxTop) Top = maxTop;
+
+        ScheduleSavePosition();
+    }
+
+    private void ScheduleSavePosition()
+    {
+        _saveDebounce.Stop();
+        _saveDebounce.Start();
+    }
+
+    private void SavePositionCore()
     {
         _settings.Left = Left;
         _settings.Top = Top;

--- a/src/AutoRace.App/Services/OverlaySettings.cs
+++ b/src/AutoRace.App/Services/OverlaySettings.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace AutoRace.App.Services;
+
+public sealed class OverlaySettings
+{
+    public double? Left { get; set; }
+    public double? Top { get; set; }
+
+    private static string SettingsPath
+    {
+        get
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "AutoRace");
+            return Path.Combine(dir, "overlay.json");
+        }
+    }
+
+    public static OverlaySettings Load()
+    {
+        try
+        {
+            var path = SettingsPath;
+            if (!File.Exists(path)) return new OverlaySettings();
+
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<OverlaySettings>(json) ?? new OverlaySettings();
+        }
+        catch
+        {
+            return new OverlaySettings();
+        }
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var path = SettingsPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            File.WriteAllText(path, json);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+}

--- a/src/AutoRace.App/ViewModels/MainViewModel.cs
+++ b/src/AutoRace.App/ViewModels/MainViewModel.cs
@@ -1,13 +1,21 @@
 using System;
 using System.Windows.Input;
+using System.Windows.Threading;
 using AutoRace.App.Mvvm;
 
 namespace AutoRace.App.ViewModels;
 
 public sealed class MainViewModel : ObservableObject
 {
+    private readonly DispatcherTimer _timer;
+
     private string _statusText = "Ready";
     private bool _isRunning;
+    private DateTimeOffset? _startedAt;
+    private TimeSpan _elapsed;
+    private string _elapsedText = "00:00:00";
+    private int _rounds;
+    private decimal _revenue;
 
     public string StatusText
     {
@@ -23,7 +31,44 @@ public sealed class MainViewModel : ObservableObject
             if (!SetProperty(ref _isRunning, value)) return;
             (StartCommand as RelayCommand)?.RaiseCanExecuteChanged();
             (StopCommand as RelayCommand)?.RaiseCanExecuteChanged();
+
+            if (_isRunning) _timer.Start();
+            else _timer.Stop();
         }
+    }
+
+    public DateTimeOffset? StartedAt
+    {
+        get => _startedAt;
+        private set => SetProperty(ref _startedAt, value);
+    }
+
+    public TimeSpan Elapsed
+    {
+        get => _elapsed;
+        private set
+        {
+            if (!SetProperty(ref _elapsed, value)) return;
+            ElapsedText = FormatElapsed(value);
+        }
+    }
+
+    public string ElapsedText
+    {
+        get => _elapsedText;
+        private set => SetProperty(ref _elapsedText, value);
+    }
+
+    public int Rounds
+    {
+        get => _rounds;
+        set => SetProperty(ref _rounds, value);
+    }
+
+    public decimal Revenue
+    {
+        get => _revenue;
+        set => SetProperty(ref _revenue, value);
     }
 
     public ICommand StartCommand { get; }
@@ -33,10 +78,25 @@ public sealed class MainViewModel : ObservableObject
     {
         StartCommand = new RelayCommand(Start, () => !IsRunning);
         StopCommand = new RelayCommand(Stop, () => IsRunning);
+
+        _timer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(250)
+        };
+        _timer.Tick += (_, _) =>
+        {
+            if (!IsRunning || StartedAt is null) return;
+            Elapsed = DateTimeOffset.Now - StartedAt.Value;
+        };
     }
 
     private void Start()
     {
+        StartedAt = DateTimeOffset.Now;
+        Elapsed = TimeSpan.Zero;
+        Rounds = 0;
+        Revenue = 0m;
+
         IsRunning = true;
         StatusText = $"Running… ({DateTime.Now:HH:mm:ss})";
     }
@@ -45,5 +105,13 @@ public sealed class MainViewModel : ObservableObject
     {
         IsRunning = false;
         StatusText = $"Stopped. ({DateTime.Now:HH:mm:ss})";
+    }
+
+    private static string FormatElapsed(TimeSpan elapsed)
+    {
+        // Keep it stable and readable.
+        if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+        var totalHours = (int)elapsed.TotalHours;
+        return $"{totalHours:00}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
     }
 }

--- a/src/AutoRace.App/ViewModels/OverlayInfoViewModel.cs
+++ b/src/AutoRace.App/ViewModels/OverlayInfoViewModel.cs
@@ -1,0 +1,41 @@
+using AutoRace.App.Mvvm;
+
+namespace AutoRace.App.ViewModels;
+
+public sealed class OverlayInfoViewModel : ObservableObject
+{
+    private string _statusText = "Idle";
+    private string _elapsedText = "00:00:00";
+    private int _rounds;
+    private decimal _revenue;
+
+    public string StatusText
+    {
+        get => _statusText;
+        set => SetProperty(ref _statusText, value);
+    }
+
+    public string ElapsedText
+    {
+        get => _elapsedText;
+        set => SetProperty(ref _elapsedText, value);
+    }
+
+    public int Rounds
+    {
+        get => _rounds;
+        set => SetProperty(ref _rounds, value);
+    }
+
+    public decimal Revenue
+    {
+        get => _revenue;
+        set
+        {
+            if (!SetProperty(ref _revenue, value)) return;
+            OnPropertyChanged(nameof(RevenueText));
+        }
+    }
+
+    public string RevenueText => $"{Revenue:N0}";
+}


### PR DESCRIPTION
Implements #7.

- Adds always-on-top OverlayInfoWindow showing Status / Elapsed / Rounds / Revenue.
- Overlay auto-shows on Start and hides on Stop.
- Overlay is draggable; persists last position to %APPDATA%/AutoRace/overlay.json.

Notes:
- This wires overlay lifecycle via minimal MainWindow code-behind; values are MVVM-bound.
- Live Elapsed updates via DispatcherTimer while running.