### PR TITLE
feat(infra): Win32 pixel reader abstraction

### DIFF
--- a/src/AutoRace.Core/Screen/IPixelReader.cs
+++ b/src/AutoRace.Core/Screen/IPixelReader.cs
@@ -7,9 +7,9 @@ public interface IPixelReader
 
 public readonly record struct Rgb24(byte R, byte G, byte B)
 {
-    public int ToRgb() => (R << 16) | (G << 8) | B;
+    public uint ToRgb() => (uint)((R << 16) | (G << 8) | B);
 
-    public static Rgb24 FromRgb(int rgb)
+    public static Rgb24 FromRgb(uint rgb)
     {
         var r = (byte)((rgb >> 16) & 0xFF);
         var g = (byte)((rgb >> 8) & 0xFF);

--- a/src/AutoRace.Core/Screen/IPixelReader.cs
+++ b/src/AutoRace.Core/Screen/IPixelReader.cs
@@ -1,0 +1,21 @@
+namespace AutoRace.Core.Screen;
+
+public interface IPixelReader
+{
+    Rgb24 GetColorAt(int x, int y);
+}
+
+public readonly record struct Rgb24(byte R, byte G, byte B)
+{
+    public int ToRgb() => (R << 16) | (G << 8) | B;
+
+    public static Rgb24 FromRgb(int rgb)
+    {
+        var r = (byte)((rgb >> 16) & 0xFF);
+        var g = (byte)((rgb >> 8) & 0xFF);
+        var b = (byte)(rgb & 0xFF);
+        return new Rgb24(r, g, b);
+    }
+
+    public override string ToString() => $"#{R:X2}{G:X2}{B:X2}";
+}

--- a/src/AutoRace.Infrastructure/Screen/Win32PixelReader.cs
+++ b/src/AutoRace.Infrastructure/Screen/Win32PixelReader.cs
@@ -8,10 +8,7 @@ public sealed class Win32PixelReader : IPixelReader
 {
     public Win32PixelReader()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            throw new PlatformNotSupportedException("Win32 pixel reading is only supported on Windows.");
-        }
+        if (!OperatingSystem.IsWindows()) throw new PlatformNotSupportedException("Win32 pixel reading is only supported on Windows.");
     }
 
     public Rgb24 GetColorAt(int x, int y)

--- a/src/AutoRace.Infrastructure/Screen/Win32PixelReader.cs
+++ b/src/AutoRace.Infrastructure/Screen/Win32PixelReader.cs
@@ -1,0 +1,43 @@
+using System;
+using AutoRace.Core.Screen;
+using AutoRace.Infrastructure.Win32;
+
+namespace AutoRace.Infrastructure.Screen;
+
+public sealed class Win32PixelReader : IPixelReader
+{
+    public Win32PixelReader()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException("Win32 pixel reading is only supported on Windows.");
+        }
+    }
+
+    public Rgb24 GetColorAt(int x, int y)
+    {
+        var hdc = Win32Api.GetDC(IntPtr.Zero);
+        if (hdc == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("GetDC returned a null handle.");
+        }
+
+        try
+        {
+            var colorRef = Win32Api.GetPixel(hdc, x, y);
+            if (colorRef == 0xFFFFFFFF)
+            {
+                throw new InvalidOperationException("GetPixel failed.");
+            }
+
+            var r = (byte)(colorRef & 0xFF);
+            var g = (byte)((colorRef >> 8) & 0xFF);
+            var b = (byte)((colorRef >> 16) & 0xFF);
+            return new Rgb24(r, g, b);
+        }
+        finally
+        {
+            _ = Win32Api.ReleaseDC(IntPtr.Zero, hdc);
+        }
+    }
+}

--- a/src/AutoRace.Infrastructure/Win32/Win32Api.cs
+++ b/src/AutoRace.Infrastructure/Win32/Win32Api.cs
@@ -21,6 +21,24 @@ public static class Win32Api
     public static IntPtr FindWindowByTitle(string? title) => FindWindow(null, title);
 
     /// <summary>
+    /// Retrieves a handle to a device context (DC) for the client area of a window.
+    /// </summary>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr GetDC(IntPtr hwnd);
+
+    /// <summary>
+    /// Releases a device context (DC), freeing it for use by other applications.
+    /// </summary>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+
+    /// <summary>
+    /// Retrieves the RGB color value of the pixel at the specified coordinates.
+    /// </summary>
+    [DllImport("gdi32.dll", SetLastError = true)]
+    public static extern uint GetPixel(IntPtr hdc, int x, int y);
+
+    /// <summary>
     /// Performs a bit-block transfer of the color data from a source device context to a destination device context.
     /// </summary>
     [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]


### PR DESCRIPTION
Implements a minimal screen/pixel infrastructure abstraction (issue #5).

- AutoRace.Core: add IPixelReader + Rgb24 value type (platform-agnostic)
- AutoRace.Infrastructure: add Win32PixelReader (GetDC/GetPixel/ReleaseDC)
- Win32Api: add P/Invokes for GetDC/ReleaseDC/GetPixel

Notes:
- Win32PixelReader throws PlatformNotSupportedException when not on Windows.

Closes #5.
