### PR TITLE
feat(infra): JSON settings storage + optional registry import

### DIFF
--- a/src/AutoRace.Core/Settings/ISettingsStore.cs
+++ b/src/AutoRace.Core/Settings/ISettingsStore.cs
@@ -1,0 +1,22 @@
+namespace AutoRace.Core.Settings;
+
+/// <summary>
+/// Defines asynchronous load/save operations for persisted settings.
+/// </summary>
+public interface ISettingsStore<T>
+{
+    /// <summary>
+    /// Gets the backing storage path.
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    /// Loads the settings value if present; returns null when missing.
+    /// </summary>
+    Task<T?> LoadAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Saves the provided settings value to storage.
+    /// </summary>
+    Task SaveAsync(T value, CancellationToken ct = default);
+}

--- a/src/AutoRace.Infrastructure/Settings/JsonFileSettingsStore.cs
+++ b/src/AutoRace.Infrastructure/Settings/JsonFileSettingsStore.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using AutoRace.Core.Settings;
+
+namespace AutoRace.Infrastructure.Settings;
+
+/// <summary>
+/// Persists settings to a JSON file on disk.
+/// </summary>
+public sealed class JsonFileSettingsStore<T> : ISettingsStore<T>
+{
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the JSON settings store.
+    /// </summary>
+    public JsonFileSettingsStore(string path, JsonSerializerOptions? serializerOptions = null)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("Settings path must be provided.", nameof(path));
+        }
+
+        Path = path;
+        _serializerOptions = serializerOptions ?? new JsonSerializerOptions { WriteIndented = true };
+    }
+
+    /// <inheritdoc />
+    public string Path { get; }
+
+    /// <inheritdoc />
+    public async Task<T?> LoadAsync(CancellationToken ct = default)
+    {
+        if (!File.Exists(Path))
+        {
+            return default;
+        }
+
+        await using var stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return await JsonSerializer.DeserializeAsync<T>(stream, _serializerOptions, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(T value, CancellationToken ct = default)
+    {
+        var directory = System.IO.Path.GetDirectoryName(Path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = new FileStream(Path, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, value, _serializerOptions, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/AutoRace.Infrastructure/Settings/WindowsRegistrySettingsImporter.cs
+++ b/src/AutoRace.Infrastructure/Settings/WindowsRegistrySettingsImporter.cs
@@ -1,0 +1,84 @@
+using Microsoft.Win32;
+
+namespace AutoRace.Infrastructure.Settings;
+
+/// <summary>
+/// Reads settings values from the Windows registry.
+/// </summary>
+public sealed class WindowsRegistrySettingsImporter
+{
+    private readonly RegistryKey _baseKey;
+
+    /// <summary>
+    /// Initializes a new registry importer using the provided base key.
+    /// </summary>
+    public WindowsRegistrySettingsImporter(RegistryKey? baseKey = null)
+    {
+        _baseKey = baseKey ?? Registry.CurrentUser;
+    }
+
+    /// <summary>
+    /// Attempts to read a string or expanded string value from the registry.
+    /// </summary>
+    public string? TryReadStringValue(string subKeyPath, string valueName)
+    {
+        if (string.IsNullOrWhiteSpace(subKeyPath) || string.IsNullOrWhiteSpace(valueName))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var key = _baseKey.OpenSubKey(subKeyPath, writable: false);
+            if (key is null)
+            {
+                return null;
+            }
+
+            var kind = key.GetValueKind(valueName);
+            if (kind is not RegistryValueKind.String and not RegistryValueKind.ExpandString)
+            {
+                return null;
+            }
+
+            return key.GetValue(valueName) as string;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to read a 32-bit integer (DWORD) value from the registry.
+    /// </summary>
+    public int? TryReadInt32Value(string subKeyPath, string valueName)
+    {
+        if (string.IsNullOrWhiteSpace(subKeyPath) || string.IsNullOrWhiteSpace(valueName))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var key = _baseKey.OpenSubKey(subKeyPath, writable: false);
+            if (key is null)
+            {
+                return null;
+            }
+
+            var kind = key.GetValueKind(valueName);
+            if (kind != RegistryValueKind.DWord)
+            {
+                return null;
+            }
+
+            var value = key.GetValue(valueName);
+            return value is int intValue ? intValue : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Implements #4.

What’s included:
- AutoRace.Core: ISettingsStore<T> abstraction (async Load/Save + Path)
- AutoRace.Infrastructure: JsonFileSettingsStore<T> using System.Text.Json
- AutoRace.Infrastructure: WindowsRegistrySettingsImporter helper (safe, generic reads; caller supplies subkey + value name)

Notes:
- Store creates parent directory on save; load returns null when file missing.
- Build/test should be validated by CI (local dotnet SDK not available in this environment).
